### PR TITLE
Fix copying of email address in mailto link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/electron-spellchecker",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Implement spellchecking, correctly",
   "scripts": {
     "doc": "esdoc -c ./esdoc.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/electron-spellchecker",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Implement spellchecking, correctly",
   "scripts": {
     "doc": "esdoc -c ./esdoc.json",

--- a/src/context-menu-builder.js
+++ b/src/context-menu-builder.js
@@ -158,8 +158,9 @@ export default class ContextMenuBuilder {
       click: () => {
         let url = menuInfo.linkURL;
         if (isEmailAddress) {
-          // Omit the mailto: portion of the link; we just want the address
-          url = url.slice('mailto:'.length);
+          // Omit the mailto: portion of the link (and the potential query parameters);
+          // we just want the address
+          url = url.slice('mailto:'.length).split('?')[0];
         }
         clipboard.writeText(url);
       }

--- a/src/context-menu-builder.js
+++ b/src/context-menu-builder.js
@@ -156,9 +156,12 @@ export default class ContextMenuBuilder {
     let copyLink = new MenuItem({
       label: isEmailAddress ? this.stringTable.copyMail() : this.stringTable.copyLinkUrl(),
       click: () => {
-        // Omit the mailto: portion of the link; we just want the address
-        clipboard.writeText(isEmailAddress ?
-          menuInfo.linkText : menuInfo.linkURL);
+        let url = menuInfo.linkURL;
+        if (isEmailAddress) {
+          // Omit the mailto: portion of the link; we just want the address
+          url = url.slice('mailto:'.length);
+        }
+        clipboard.writeText(url);
       }
     });
 


### PR DESCRIPTION
Previously:
When the link text was "foo" and the link url was "mailto:foo@bar.com".
Copying the email address would add "foo" to the clipboard.

Now:
Copying the email address adds "foo@bar.com" to the clipboard.
