### PR TITLE
Fix ars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/electron-spellchecker",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Implement spellchecking, correctly",
   "scripts": {
     "doc": "esdoc -c ./esdoc.json",

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -649,10 +649,6 @@ module.exports = class SpellCheckHandler {
       // NB: OS X will return lists that are half just a language, half
       // language + locale, like ['en', 'pt_BR', 'ko']
       localeList = this.currentSpellchecker.getAvailableDictionaries()
-      // ars is the language code for a form of arabic
-      // electron-spellchecker does not handle languages without a locale
-      // causing it to fail on this type of language
-        .filter(lang => lang !== 'ars')
         .map((x => {
           if (x.length === 2) return fallbackLocaleTable[x];
           return normalizeLanguageCode(x);

--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -649,6 +649,10 @@ module.exports = class SpellCheckHandler {
       // NB: OS X will return lists that are half just a language, half
       // language + locale, like ['en', 'pt_BR', 'ko']
       localeList = this.currentSpellchecker.getAvailableDictionaries()
+      // ars is the language code for a form of arabic
+      // electron-spellchecker does not handle languages without a locale
+      // causing it to fail on this type of language
+        .filter(lang => lang !== 'ars')
         .map((x => {
           if (x.length === 2) return fallbackLocaleTable[x];
           return normalizeLanguageCode(x);

--- a/src/utility.js
+++ b/src/utility.js
@@ -14,7 +14,7 @@ function normalizeLanguageCode(langCode) {
   if (!result || !result.langtag.language) {
     throw new Error(`${langCode} is not a valid language code`);
   }
-  let region = result.langtag.region ? '' : '-' + result.langtag.region.toUpperCase()
+  let region = result.langtag.region ? ('-' + result.langtag.region.toUpperCase()) : ''
 
   return `${result.langtag.language.language.toLowerCase()}${region}`;
 }

--- a/src/utility.js
+++ b/src/utility.js
@@ -11,11 +11,12 @@ const { parse } = require('bcp47');
  */
 function normalizeLanguageCode(langCode) {
   let result = parse(langCode.replace(/[_-]/g, '-'));
-  if (!result || !result.langtag.language || !result.langtag.region) {
+  if (!result || !result.langtag.language) {
     throw new Error(`${langCode} is not a valid language code`);
   }
+  let region = result.langtag.region ? '' : '-' + result.langtag.region.toUpperCase()
 
-  return `${result.langtag.language.language.toLowerCase()}-${result.langtag.region.toUpperCase()}`;
+  return `${result.langtag.language.language.toLowerCase()}${region}`;
 }
 
 /**


### PR DESCRIPTION
The electron spellchecker is sending languages without regions to this fn. Realistically this fn should be able to handle those types of languages and still normalize the language code.

