### PR TITLE
Update version check for electron > 10

### DIFF
--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -382,7 +382,7 @@ module.exports = class SpellCheckHandler {
     let dict = null;
 
     this.isMisspelledCache.reset();
-    
+
     // Set language on macOS
     if (isMac && this.currentSpellchecker) {
       d(`Setting current spellchecker to ${langCode}`);
@@ -463,7 +463,8 @@ module.exports = class SpellCheckHandler {
    *  @param {*} webFrame
    */
   setSpellCheckProvider(webFrame) {
-    if (process.versions.electron >= '5.0.0') {
+    let majorVersion = parseInt(process.versions.electron.split('.')[0])
+    if (majorVersion >= 5) {
       webFrame.setSpellCheckProvider(
         this.currentSpellcheckerLanguage,
         { spellCheck: this.handleElectronSpellCheck.bind(this) });
@@ -495,7 +496,7 @@ module.exports = class SpellCheckHandler {
   }
 
   /**
-   *  The actual callout called by Electron version 5 and above to handle 
+   *  The actual callout called by Electron version 5 and above to handle
    *  spellchecking.
    *  @private
    */


### PR DESCRIPTION
The previous method of checking the version does not work for version 10 and up.
`'10.0.0' >= '5.0.0' // false` 😄 
I'm going to make a pr for the upstream lib but fixing it in our fork for now